### PR TITLE
Add support for subscriptions/v1 endpoints

### DIFF
--- a/planet/api/client.py
+++ b/planet/api/client.py
@@ -582,3 +582,90 @@ class ClientV1(_Base):
         '''
 
         return self._get(location, models.JSON, callback=callback)
+
+    def get_delivery_subscriptions(self):
+        '''Get information for all subscriptions for the current user, including
+        cancelled subscriptions
+
+        :returns: :py:Class:`planet.api.models.PublishingSubscriptions`
+        '''
+        return self._get(
+            self._url('subscriptions/v1/'),
+            models.DeliverySubscriptions
+        ).get_body()
+
+    def get_individual_delivery_subscription(self, subscription_id):
+        '''Get subscription details by ID
+
+        :param subscription_id str: The ID of the Subscription
+        :returns: :py:class:`planet.api.models.JSON`
+        :raises planet.api.exceptions.APIException: On API error.
+        '''
+        return self._get(
+            self._url('subscriptions/v1/{}'.format(subscription_id)),
+            body_type=models.JSON
+        ).get_body()
+
+    def cancel_delivery_subscription(self, subscription_id):
+        '''Cancel a running subscription by subscription ID
+
+        Subscriptions can only be cancelled in Pending or Running State.
+
+        :param subscription_id str: The ID of the Subscription
+        :returns: :py:Class:`planet.api.models.DeliverySubscription`
+        :raises planet.api.exceptions.APIException: On API error.
+        '''
+        return self.dispatcher.response(
+            models.Request(
+                self._url('subscriptions/v1/{}/cancel'.format(subscription_id)),
+                self.auth,
+                body_type=models.Body,
+                method='POST'
+            )
+        ).get_body()
+
+    def create_delivery_subscription(self, request):
+        '''Create a subscription.
+
+        :param request: subscription request
+        :returns: :py:class:`planet.api.models.JSON`
+        :raises planet.api.exceptions.APIException: On API error.
+        '''
+        return self.dispatcher.response(
+            models.Request(
+                self._url('subscriptions/v1/'),
+                self.auth,
+                body_type=models.JSON,
+                data=json.dumps(request),
+                method='POST'
+            )
+        ).get_body()
+
+    def get_delivery_subscription_results(self, subscription_id, status=None, created=None, updated=None,
+                                          completed=None):
+        '''Get results for a given subscription
+
+        :param subscription_id str: Subscription ID
+        :param status str: Enum: "created" "queued" "processing" "failed" "success"
+        :param created str: Only return results that were created in the given interval or instant.
+        :param updated str: Only return results that were updated in the given interval or instant.
+        :param completed str: Only return results that were completed in the given interval or instant.
+        :returns :py:class:`planet.api.models.JSON`
+        :raises planet.api.exceptions.APIException: On API error.
+        '''
+        params = {}
+
+        if status:
+            params['status'] = status
+        if created:
+            params['created'] = created
+        if updated:
+            params['updated'] = updated
+        if completed:
+            params['completed'] = completed
+
+        return self._get(
+            self._url('subscriptions/v1/{}/results'.format(subscription_id)),
+            body_type=models.JSON,
+            params=params,
+        ).get_body()

--- a/planet/api/filters.py
+++ b/planet/api/filters.py
@@ -36,6 +36,28 @@ def build_search_request(filter_like, item_types, name=None, interval=None):
         req['interval'] = interval
     return req
 
+def build_delivery_subscription_request(filter_like, name, item_types, asset_types, delivery, tools=None):
+    '''Build a subscription-api creation request body for the specified item_types.
+    '''
+    filter_spec = filter_like.get('filter', filter_like)
+    all_items = list(set(filter_like.get('item_types', [])).union(item_types))
+    req = {
+        'name': name,
+        'source': {
+            'type': 'catalog',
+            'parameters': {
+                'item_types': all_items,
+                'asset_types': asset_types,
+                'filter': filter_spec,
+            }
+        },
+        'delivery': delivery,
+    }
+    if tools:
+        req['tools'] = tools
+    return req
+
+
 
 def is_filter_like(filter_like):
     '''Check if the provided dict looks like a search request or filter.'''
@@ -145,7 +167,6 @@ def geom_filter(geom, field_name=None):
     '''
     return _filter('GeometryFilter', config=geom,
                    field_name=field_name or 'geometry')
-
 
 def num_filter(field_name, *vals):
     '''Build a NumberInFilter.

--- a/planet/api/models.py
+++ b/planet/api/models.py
@@ -325,6 +325,11 @@ class Orders(Paged):
     NEXT_KEY = 'next'
 
 
+class DeliverySubscriptions(Paged):
+    ITEM_KEY = 'subscriptions'
+    NEXT_KEY = 'next'
+
+
 class Order(JSON):
     LINKS_KEY = '_links'
     RESULTS_KEY = 'results'

--- a/scripts/subscriptions/readme.md
+++ b/scripts/subscriptions/readme.md
@@ -1,0 +1,166 @@
+# Planet Subscription API
+
+https://developers.planet.com/docs/subscriptions/
+
+The following methods have been added: 
+- `api.filters.build_delivery_subscription_request`
+- `api.ClientV1.create_delivery_subscription`
+- `api.ClientV1.cancel_delivery_subscription`
+- `api.ClientV1.get_individual_delivery_subscription`
+- `api.ClientV1.get_delivery_subscriptions`
+- `api.ClientV1.get_delivery_subscription_results`
+
+I used 'delivery subscriptions' instead of 'subscriptions' as there is already a 
+'subscription' within planet namespace for analytic subscriptions. 
+
+To use the subscriptions API, create a client. You'll need an API key, usually 
+stored in `PL_API_KEY`. 
+```
+import os
+from planet import api
+
+client = api.ClientV1(os.environ['PL_API_KEY'])
+```
+
+To fetch a subscription by ID, use...
+```
+subscription_id = '56b4c00d-062e-4c5c-8d8c-860c789665ef'
+subscription = client.get_individual_delivery_subscription(subscription_id)
+
+print(subscription)
+```
+
+If the subscription can't be found, the API will raise the 
+`planet.api.exceptions.MissingResource` exception.
+
+To fetch all subscriptions that your user has access to, use...
+```
+subscriptions = client.get_delivery_subscriptions()
+
+print(subscriptions)
+```
+
+To cancel a subscription with the given ID, use...
+```
+subscription_id = '56b4c00d-062e-4c5c-8d8c-860c789665ef'
+result = client.cancel_delivery_subscription(subscription_id)
+
+print(result.response.status_code)
+```
+
+This will return an empty response with a status code of 200 if the cancellation
+is successful. You can only cancel a subscription that has a `status` of 'pending
+' or 'running'. Otherwise the API will raise the `planet.api.exceptions.BadQuery`
+exception.
+
+To create a subscription, you'll need some more information.
+
+Create a geometry with the coordinates you'd like to subscribe to...
+```
+aoi = [[[...], [...]]]
+geom = {
+    'coordinates': aoi,
+    'type': 'MultiPolygon',
+}
+```
+
+then define what types of products you'd like to receive...
+```
+item_types = [
+    'PSOrthoTile'
+]
+
+asset_types = [
+    "analytic",
+    "analytic_xml",
+    "udm",
+    "udm2"
+]
+```
+
+You can use `api.filters` the same way that you use them when creating a Quick Search. 
+Let's use a geometry filter, along with a date range, and an instrument name. This will 
+filter imagery that contains our AOI, from 2021-09-18 until 2021-09-21, for only PS2 and 
+PS2.SD instrument types. 
+
+Remember that currently, you can only create subscriptions starting in the future. There
+is no back-fill functionality for the subscriptions API. The API will return an error
+if the `gt` date is in the past.
+
+```
+filters = api.filters.and_filter(
+    api.filters.geom_filter(geom, 'geometry'),
+    api.filters.date_range('published', gt='2021-09-18', lte='2021-09-21'),
+    api.filters.string_filter('instrument', 'PS2', 'PS2.SD')
+)
+
+tools = []
+```
+
+Tools are not required and the only 'tool' supported is image `clip`. We want 
+all our returned imagery to be clipped to our AOI boundary, so let's define 
+`tools` with the same AOI as our geometry filter...
+
+```
+    tools = [
+        {
+            'type': 'clip',
+            'parameters': {
+                'aoi': {
+                    'coordinates': [[[...], [...]]],
+                    'type': 'MultiPolygon' 
+                }
+            }
+        }
+    ]
+```
+
+Define your delivery location. The subscriptions API only supports cloud delivery.
+We're using Google Cloud Storage...
+
+``` 
+delivery = {
+    'type': 'google_cloud_storage',
+    'parameters': {
+        'bucket': '...',
+        'credentials': '...'
+    }
+}
+```
+
+Give your subscription a name (not required to be unique but probably should be)
+and wa-la! It's done. 
+
+```
+name = 'my-subscription-for-this-area'
+
+request = api.filters.build_delivery_subscription_request(
+    filters,
+    name,
+    item_types,
+    asset_types,
+    delivery, 
+    tools
+)
+
+result = client.create_delivery_subscription(request)
+```
+
+The API will raise exceptions if your geometry is invalid, your AOI contains > 500 vertices, 
+you have self-intersecting geometry, and such. So make sure you follow the rules! 
+
+_Your cloud delivery credentials will be tested when you create a subscription. 
+If they are invalid or do not have the required permissions, the API will raise
+an exception. So if your request returns OK, you're in the clear._
+
+After a few days (hopefully the next day) you should start receiving deliveries in your cloud 
+storage. The follow the name/directory format of `storage-id/subscription-id/delivery-id/file-names...`
+
+You can also view the delivered results of a given subscription id with...
+```
+subscription_id = '56b4c00d-062e-4c5c-8d8c-860c789665ef'
+results = client.get_delivery_subscription_results(subscription_id)
+```
+
+You can also query for results with a `created` or `updated` or `completed` in 
+a some date range by adding them as arguments.

--- a/scripts/subscriptions/test_get_subscription.py
+++ b/scripts/subscriptions/test_get_subscription.py
@@ -1,0 +1,12 @@
+import os
+from pprint import pprint as print
+
+from planet import api
+
+client = api.ClientV1(os.environ['PL_API_KEY'])
+
+subscription_id = '61977bc7-0683-4ed4-b183-b420041f0650'
+
+subscription = client.get_individual_delivery_subscription(subscription_id)
+
+print(subscription.get())


### PR DESCRIPTION
See the [README.md](https://github.com/Godron629/planet-client-python/blob/6e8fcb6028ba1de9d1ca25141d1402aba4344572/scripts/subscriptions/readme.md)

This does not add CLI support, only though `ClientV1`.